### PR TITLE
fix: 日付押しても最後のコマが選択されない不具合を修正

### DIFF
--- a/src/components/Form/TableForm.tsx
+++ b/src/components/Form/TableForm.tsx
@@ -52,10 +52,10 @@ export const TableForm = ({
       setSelected([
         ...filterd,
         ...[...Array(periods)].map((_, index) => ({
-          id: stringDate + "-" + index,
+          id: `${stringDate}-${index + 1}`,
           date: new Date(stringDate),
           stringDate: stringDate,
-          period: index,
+          period: index + 1,
         })),
       ]);
     }


### PR DESCRIPTION
## 概要
- テーブルフォームで、日付を押しても最後のコマだけ選択されないバグを修正

## 関連 Issue
<!-- #のあとにIssue番号を記載すると、PRがマージされた時に自動でIssueをcloseすることができます。 -->
- close #5 

## やったこと
- テーブルフォームで、日付を押しても最後のコマだけ選択されないバグを修正
